### PR TITLE
Remove cs/useless-cast-to-self and cs/useless-upcast

### DIFF
--- a/.github/codeql/csharp-custom-queries.qls
+++ b/.github/codeql/csharp-custom-queries.qls
@@ -35,3 +35,5 @@
     id: cs/missed-readonly-modifier
     id: cs/linq/missed-select
     id: cs/missed-ternary-operator
+    id: cs/useless-upcast
+    id: cs/useless-cast-to-self


### PR DESCRIPTION
Remove cs/useless-cast-to-self and cs/useless-upcast, these are firing on auto generated code making more noise then value.